### PR TITLE
Improve Docker setup for EasyPanel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
-# Usa uma imagem oficial Python slim
 FROM python:3.12-slim
 
-# Instala dependências do sistema
-RUN apt-get update && apt-get install -y build-essential
+ENV PYTHONUNBUFFERED=1
+ENV PORT=5000
 
-# Cria diretório da aplicação
 WORKDIR /app
 
-# Copia os arquivos de dependências
 COPY requirements.txt .
-
-# Instala dependências Python
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia todo o código-fonte da aplicação
 COPY . .
 
-# Define a porta da aplicação Flask
 EXPOSE 5000
 
-# Executa a aplicação Flask
-CMD ["python", "app.py"]
+CMD ["sh", "-c", "gunicorn -b 0.0.0.0:${PORT} wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Aplicação Flask que consulta o endpoint `https://cgg.bet.br` e exibe em tempo 
    ```bash
    docker build -t rtp-cgg .
    ```
-2. Execute o container na porta 5000:
+2. Execute o container informando a porta desejada (padrão `5000`):
    ```bash
-   docker run -p 5000:5000 rtp-cgg
+   docker run -e PORT=5000 -p 5000:5000 rtp-cgg
    ```
 3. Acesse `http://localhost:5000` para visualizar o dashboard.
+
+Esse mesmo Dockerfile funciona em plataformas como o **EasyPanel**, bastando informar a variável `PORT` caso a hospedagem utilize outra porta padrão.
 
 ## Scripts disponíveis
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 flask
 requests
 protobuf
+
+gunicorn
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- use gunicorn as the entrypoint
- allow port configuration via PORT env var
- document Docker usage for EasyPanel

## Testing
- `python -m py_compile app.py wsgi.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68682082b430832cb26f235cc81f97c3