### PR TITLE
Add GPT-4 recommendations endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ O projeto não exige variáveis de ambiente obrigatórias, mas algumas opções 
 - `FLASK_APP` e `FLASK_ENV` podem ser usados ao executar via `flask run`.
 - `PORT` pode definir a porta do servidor caso utilize o comando `flask run`.
 - A constante `DEBUG_REQUESTS` em `app.py` habilita logs detalhados (por padrão vem ativada).
+- `OPENAI_API_KEY` chave de acesso à API da OpenAI para geração de recomendações.
 
 
 Aplicação Flask que exibe os dados de RTP de jogos em tempo real.
+
+## Recomendações com OpenAI
+
+Defina a variável `OPENAI_API_KEY` com a sua chave da OpenAI para habilitar o endpoint `/api/recommendations`.
+No painel, clique em **Gerar Recomendações** para obter sugestões de jogos com maior potencial de pagamento.
 
 ## Verificação SSL
 Por padrão, as requisições HTTPS verificam o certificado do servidor. Para manter a segurança, **não desative** essa verificação em ambientes de produção.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 requests
 protobuf
 gunicorn
+openai

--- a/static/script.js
+++ b/static/script.js
@@ -128,6 +128,36 @@ document.addEventListener('DOMContentLoaded', () => {
 setInterval(fetchGames, 5000);
 fetchGames();
 
+async function generateRecommendations() {
+    const container = document.getElementById('recommendations-container');
+    if (container) container.textContent = 'Gerando recomendações...';
+    try {
+        const response = await fetch('/api/recommendations', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(gamesData)
+        });
+        if (!response.ok) throw new Error('Request failed');
+        const data = await response.json();
+        displayRecommendations(data.recomendacoes || []);
+    } catch (err) {
+        console.error('Erro ao gerar recomendações:', err);
+        if (container) container.textContent = 'Falha ao gerar recomendações';
+    }
+}
+
+function displayRecommendations(list) {
+    const container = document.getElementById('recommendations-container');
+    if (!container) return;
+    container.innerHTML = '<h3 class="mb-3">Recomendações</h3>';
+    list.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'mb-2';
+        div.innerHTML = `<strong>${item.nome}</strong> - ${item.prioridade} <br><small>${item.motivo}</small>`;
+        container.appendChild(div);
+    });
+}
+
 document.addEventListener('click', async (e) => {
     if (e.target.classList.contains('card-title')) {
         const text = e.target.textContent.trim();

--- a/static/style.css
+++ b/static/style.css
@@ -59,3 +59,7 @@ body {
 #copy-toast.show {
     opacity: 1;
 }
+
+#recommendations-container {
+    text-align: left;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,7 @@
             <button class="btn btn-success" onclick="sortBy('rtp')">🔼 Ordenar por RTP</button>
             <button class="btn btn-info" onclick="sortBy('name')">🔤 Ordenar por Nome</button>
             <button class="btn btn-warning" onclick="fetchGames()">🔄 Atualizar Agora</button>
+            <button class="btn btn-primary" onclick="generateRecommendations()">💡 Gerar Recomendações</button>
         </div>
 
         <div id="status-message" class="alert alert-danger d-none mt-3" role="alert"></div>
@@ -26,6 +27,7 @@
             </div>
         </div>
         <div id="games-container" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4"></div>
+        <div id="recommendations-container" class="mt-4"></div>
         <div id="copy-toast" aria-live="polite"></div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- integrate OpenAI ChatCompletion and add `/api/recommendations`
- update requirements with `openai`
- add button and container for game recommendations
- implement JS handlers to request and display recommendations
- minor styles for recommendation panel
- document usage of `OPENAI_API_KEY` in README

## Testing
- `python -m py_compile app.py`
- `python -m py_compile wsgi.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68684ea5d8c0832c8d2b05759faaee77