### PR TITLE
Remove OpenAI usage and improve filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,8 @@ O projeto não exige variáveis de ambiente obrigatórias, mas algumas opções 
 - `PORT` pode definir a porta do servidor caso utilize o comando `flask run`.
 - Defina `DEBUG_REQUESTS=true` para registrar detalhes das chamadas HTTP.
 - A variável `FLASK_DEBUG` controla o modo debug do Flask.
-- `OPENAI_API_KEY` chave de acesso à API da OpenAI para geração de recomendações.
-
 
 Aplicação Flask que exibe os dados de RTP de jogos em tempo real.
-
-## Recomendações com OpenAI
-
-Defina a variável `OPENAI_API_KEY` com a sua chave da OpenAI para habilitar o endpoint `/api/recommendations`.
-No painel, clique em **Gerar Recomendações** para obter sugestões de jogos com maior potencial de pagamento.
 
 ## Verificação SSL
 Por padrão, as requisições HTTPS verificam o certificado do servidor. Para manter a segurança, **não desative** essa verificação em ambientes de produção.

--- a/app.py
+++ b/app.py
@@ -1,11 +1,8 @@
-from flask import Flask, render_template, jsonify, request
+from flask import Flask, render_template, jsonify
 import os
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 import requests
-import openai
-import json
-import re
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
 from google.protobuf.descriptor_pool import DescriptorPool
@@ -104,49 +101,6 @@ def games():
     return jsonify(games)
 
 
-@app.route('/api/recommendations', methods=['POST'])
-def recommendations():
-    api_key = os.environ.get('OPENAI_API_KEY')
-    if not api_key:
-        return jsonify({'error': 'OPENAI_API_KEY not configured'}), 500
-
-    payload = request.get_json(silent=True)
-    if not isinstance(payload, list):
-        return jsonify({'error': 'Invalid payload'}), 400
-
-    openai.api_key = api_key
-    prompt = (
-        "Analise a lista de jogos a seguir e indique aqueles com maior potencial de pagamento. "
-        "Baseie-se no campo 'rtp' e no status 'rtp_status' (up, down ou neutral). "
-        "Responda SOMENTE com JSON PURO no formato: "
-        "{\"recomendacoes\":[{\"nome\":\"\",\"rtp\":0.0,\"prioridade\":\"Alta|Média|Baixa\",\"motivo\":\"\"}]}"
-    )
-
-    try:
-        completion = openai.ChatCompletion.create(
-            model="gpt-4",
-            messages=[
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": f"{json.dumps(payload, ensure_ascii=False)}"}
-            ],
-            temperature=0.2,
-        )
-        content = completion.choices[0].message.content.strip()
-
-        # Extrai só o JSON da resposta
-        json_match = re.search(r"({.*})", content, re.DOTALL)
-        if not json_match:
-            raise ValueError("A resposta do modelo não continha JSON válido.")
-        data = json.loads(json_match.group(1))
-
-        # Se não vier recomendacoes, força uma lista vazia
-        if "recomendacoes" not in data:
-            data["recomendacoes"] = []
-
-        return jsonify(data)
-
-    except Exception as exc:
-        return jsonify({'error': str(exc)}), 500
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ flask
 requests
 protobuf
 gunicorn
-openai

--- a/static/style.css
+++ b/static/style.css
@@ -36,6 +36,16 @@ body {
 
 .controls {
     margin-bottom: 25px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-start;
+    text-align: left;
+}
+
+.controls .form-control,
+.controls .form-select {
+    width: auto;
 }
 
 .card-title {
@@ -60,17 +70,3 @@ body {
     opacity: 1;
 }
 
-#recommendations-container {
-    text-align: left;
-}
-
-.resizable-modal {
-    max-width: none;
-    resize: both;
-    overflow: auto;
-}
-
-.resizable-modal.minimized {
-    height: 40px !important;
-    overflow: hidden;
-}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,15 +10,27 @@
     <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </head>
 <body>
-    <div class="container text-center">
-        <h1 class="mb-4">🎰 RTP dos Jogos - Tempo Real</h1>
+    <div class="container">
+        <h1 class="mb-4 text-center">🎰 RTP dos Jogos - Tempo Real</h1>
 
         <div class="controls mb-4">
-            <input id="search-input" type="text" class="form-control mb-3" placeholder="Pesquisar por nome">
+            <input id="search-input" type="text" class="form-control" placeholder="Pesquisar por nome">
+            <select id="provider-select" class="form-select">
+                <option value="all">Todos os provedores</option>
+            </select>
+            <input id="min-rtp" type="number" step="0.01" class="form-control" placeholder="RTP mín%">
+            <input id="max-rtp" type="number" step="0.01" class="form-control" placeholder="RTP máx%">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="show-positive" checked>
+                <label class="form-check-label" for="show-positive">Positivos</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="show-negative" checked>
+                <label class="form-check-label" for="show-negative">Negativos</label>
+            </div>
             <button class="btn btn-success" onclick="sortBy('rtp')">🔼 Ordenar por RTP</button>
             <button class="btn btn-info" onclick="sortBy('name')">🔤 Ordenar por Nome</button>
             <button class="btn btn-warning" onclick="fetchGames()">🔄 Atualizar Agora</button>
-            <button class="btn btn-primary" onclick="generateRecommendations()">💡 Gerar Recomendações</button>
         </div>
 
         <div id="status-message" class="alert alert-danger d-none mt-3" role="alert"></div>
@@ -27,23 +39,9 @@
                 <span class="visually-hidden">Loading...</span>
             </div>
         </div>
-        <div id="games-container" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4"></div>
+        <div id="games-container" class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-4"></div>
         <div id="copy-toast" aria-live="polite"></div>
     </div>
 
-    <div class="modal fade" id="recommendationsModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-lg resizable-modal">
-            <div class="modal-content bg-dark text-white">
-                <div class="modal-header">
-                    <h5 class="modal-title">Recomendações</h5>
-                    <div class="ms-auto">
-                        <button type="button" class="btn btn-secondary btn-sm me-2" id="minimize-modal">_</button>
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                </div>
-                <div class="modal-body" id="recommendations-container"></div>
-            </div>
-        </div>
-    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop OpenAI dependencies and code
- clean up README
- refactor layout to show more games per row
- move sorting buttons left and add filtering options
- remove recommendation modal and styles

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68685a56609c832ca3e2678faf6c2b30