### PR TITLE
Implementa cache de imagens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+image_cache/

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import urllib3
 from flask import Flask, jsonify, render_template
 from flask_socketio import SocketIO, emit
+from flask import send_file, abort
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 import requests
@@ -32,6 +33,9 @@ headers = {
 }
 data = b"\x08\x01\x10\x02"
 data_weekly = b"\x08\x02\x10\x02"
+
+IMAGE_CACHE_DIR = "image_cache"
+os.makedirs(IMAGE_CACHE_DIR, exist_ok=True)
 
 
 def get_protobuf_message():
@@ -149,6 +153,21 @@ def games():
     global latest_games
     latest_games = fetch_games_data()
     return jsonify(latest_games)
+
+
+@app.route("/imagens/<int:game_id>.webp")
+def cached_image(game_id):
+    file_path = os.path.join(IMAGE_CACHE_DIR, f"{game_id}.webp")
+    if not os.path.exists(file_path):
+        remote_url = f"https://cgg.bet.br/static/v1/casino/game/0/{game_id}/big.webp"
+        try:
+            resp = requests.get(remote_url, verify=VERIFY_SSL, timeout=10)
+            resp.raise_for_status()
+            with open(file_path, "wb") as img_file:
+                img_file.write(resp.content)
+        except requests.RequestException:
+            abort(404)
+    return send_file(file_path, mimetype="image/webp", cache_timeout=86400)
 
 
 @socketio.on("connect")

--- a/static/script.js
+++ b/static/script.js
@@ -8,6 +8,7 @@ let winnersInterval;
 let winnersModal;
 let gameModal;
 let socket;
+const IMAGE_ENDPOINT = '/imagens';
 
 function setupWinnersModal() {
     const modalEl = document.getElementById('winnersModal');
@@ -194,7 +195,7 @@ function openGameModal(id) {
     document.getElementById('gameModalLabel').textContent = game.name;
     const imgEl = document.getElementById('gameModalImg');
     if (imgEl) {
-        imgEl.src = `https://cgg.bet.br/static/v1/casino/game/0/${game.id}/big.webp`;
+        imgEl.src = `${IMAGE_ENDPOINT}/${game.id}.webp`;
         imgEl.alt = `Imagem de ${game.name}`;
     }
     const provEl = document.getElementById('gameModalProvider');
@@ -305,7 +306,7 @@ function displayGames(games) {
 
     games.forEach(game => {
         present.add(game.id);
-        const imgUrl = `https://cgg.bet.br/static/v1/casino/game/0/${game.id}/big.webp`;
+        const imgUrl = `${IMAGE_ENDPOINT}/${game.id}.webp`;
         const rtpStatus = game.rtp_status || 'neutral';
         const dailyBadge = {
             down: '<span class="badge bg-danger rtp-badge">▼ Dia</span>',


### PR DESCRIPTION
## Summary
- cria endpoint `/imagens/<id>.webp` para guardar imagens localmente
- consome essas imagens no JavaScript
- adiciona `.gitignore` para cache e `__pycache__`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686987425a44832ca69b8e2748251d1b