### PR TITLE
Fix image caching headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,11 +167,13 @@ def cached_image(game_id):
                 img_file.write(resp.content)
         except requests.RequestException:
             abort(404)
-    response = send_file(file_path, mimetype="image/webp")
+    response = send_file(
+        file_path,
+        mimetype="image/webp",
+        cache_timeout=86400,
+    )
     response.headers["Cache-Control"] = "public, max-age=86400"
     return response
-
-    return send_file(file_path, mimetype="image/webp", cache_timeout=86400)
 
 
 @socketio.on("connect")


### PR DESCRIPTION
## Summary
- remove unreachable `send_file` call in cached image route
- add caching settings to the primary response

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686acaa7d640832cafa116543da376b9