### PR TITLE
Add melhores route and prioritize games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 image_cache/
+venv/

--- a/app.py
+++ b/app.py
@@ -80,6 +80,19 @@ def decode_signed(value):
     return value
 
 
+def prioritize_games(games):
+    sorted_games = sorted(games, key=lambda g: g.get("extra", 0))
+    for game in sorted_games:
+        extra_val = game.get("extra", 0)
+        if extra_val <= -200:
+            game["prioridade"] = "🔥 Alta prioridade"
+        elif extra_val < 0:
+            game["prioridade"] = "⚠️ Média prioridade"
+        else:
+            game["prioridade"] = "✅ Neutra ou positiva"
+    return sorted_games
+
+
 def fetch_games_data():
     if DEBUG_REQUESTS:
         print("\n[DEBUG] >>> Enviando Requisição <<<")
@@ -148,11 +161,23 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/melhores")
+def melhores():
+    return render_template("melhores.html")
+
+
 @app.route("/api/games")
 def games():
     global latest_games
     latest_games = fetch_games_data()
     return jsonify(latest_games)
+
+
+@app.route("/api/melhores")
+def api_melhores():
+    global latest_games
+    latest_games = fetch_games_data()
+    return jsonify(prioritize_games(latest_games))
 
 
 @app.route("/imagens/<int:game_id>.webp")

--- a/templates/melhores.html
+++ b/templates/melhores.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>🎯 Melhores Jogos</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="{{ url_for('static', filename='script.js') }}" defer></script>
+  <script>window.USE_MELHORES_API = true;</script>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <aside class="col-md-3 col-lg-2 sidebar mb-4">
+        <div class="controls p-2 bg-dark rounded">
+          <input id="search-input" type="text" class="form-control mb-2" placeholder="🔍 Pesquisar por nome" />
+          <select id="provider-select" class="form-select mb-2">
+            <option value="all">Todos os provedores</option>
+          </select>
+          <input id="min-rtp" type="number" step="0.01" class="form-control mb-2" placeholder="RTP mínimo (%)" />
+          <input id="max-rtp" type="number" step="0.01" class="form-control mb-2" placeholder="RTP máximo (%)" />
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="show-positive" checked />
+            <label class="form-check-label" for="show-positive">Mostrar RTP Alto</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="show-negative" checked />
+            <label class="form-check-label" for="show-negative">Mostrar RTP Baixo</label>
+          </div>
+          <button class="btn btn-success w-100 mb-2" onclick="sortBy('rtp')">🔼 Ordenar por RTP</button>
+          <button class="btn btn-info w-100 mb-2" onclick="sortBy('name')">🔤 Ordenar por Nome</button>
+          <button class="btn btn-warning w-100" onclick="fetchMelhores(true)">🔄 Atualizar Agora</button>
+        </div>
+      </aside>
+      <main class="col-md-9 col-lg-10">
+        <div id="status-message" class="alert alert-danger d-none mt-3" role="alert"></div>
+        <div id="loading-spinner" class="d-none my-3">
+          <div class="spinner-border text-light" role="status">
+            <span class="visually-hidden">Carregando...</span>
+          </div>
+        </div>
+        <div id="games-container" class="games-grid"></div>
+        <div id="copy-toast" aria-live="polite"></div>
+        <audio id="alert-sound" preload="auto"></audio>
+      </main>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add function to prioritize games by `extra`
- expose `/melhores` page and `/api/melhores` endpoint
- show priority info on cards
- add new page to list prioritized games
- support new API in script

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686acaa6deac832c968e79878db8e760