### PR TITLE
Fix cache_timeout parameter in send_file

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,7 @@ def cached_image(game_id):
     response = send_file(
         file_path,
         mimetype="image/webp",
-        cache_timeout=86400,
+        max_age=86400,
     )
     response.headers["Cache-Control"] = "public, max-age=86400"
     return response


### PR DESCRIPTION
## Summary
- adjust image caching route for Flask 3 compatibility

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ad7f62970832cb60829cf770b5964