### PR TITLE
Enable real-time updates on melhores page

### DIFF
--- a/templates/melhores.html
+++ b/templates/melhores.html
@@ -7,9 +7,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script src="{{ url_for('static', filename='script.js') }}" defer></script>
-  <script>window.USE_MELHORES_API = true;</script>
-
   <script>window.IS_MELHORES_PAGE = true;</script>
 
 </head>
@@ -35,7 +34,7 @@
           <button class="btn btn-success w-100 mb-2" onclick="sortBy('rtp')">🔼 Ordenar por RTP</button>
           <button class="btn btn-info w-100 mb-2" onclick="sortBy('name')">🔤 Ordenar por Nome</button>
 
-          <button class="btn btn-warning w-100" onclick="fetchMelhores(true)">🔄 Atualizar Agora</button>
+          <button class="btn btn-warning w-100" onclick="fetchGames(true)">🔄 Atualizar Agora</button>
           <a href="/" class="btn btn-secondary w-100 mt-2">↩️ Voltar</a>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- enable websocket connection on the *melhores* page
- use generic `fetchGames` in manual refresh

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ad9111804832c8e6ec624cc3e8553