### PR TITLE
Ajusta intervalo de atualização para 3s

### DIFF
--- a/app.py
+++ b/app.py
@@ -220,7 +220,7 @@ def background_fetch():
             latest_games = fetch_games_data()
             socketio.emit("games_update", latest_games)
         finally:
-            socketio.sleep(1)
+            socketio.sleep(3)
 
 
 @app.route("/api/last-winners")

--- a/static/script.js
+++ b/static/script.js
@@ -540,7 +540,7 @@ document.addEventListener('click', async (e) => {
             }
             await fetchWinners();
             winnersModal?.show();
-            winnersInterval = setInterval(fetchWinners, 1000);
+            winnersInterval = setInterval(fetchWinners, 3000);
         } else {
             clearInterval(winnersInterval);
             winnersInterval = null;


### PR DESCRIPTION
## Summary
- aumenta intervalo do background task para 3s
- atualiza tempo de atualização dos vencedores para 3s

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686adce55930832cb872aba3e267931a