### PR TITLE
Add JWT-based admin panel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ protobuf
 gunicorn
 flask-socketio
 eventlet
+flask_sqlalchemy
+flask_jwt_extended

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Painel Administrativo</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="container py-5">
+  <h1 class="mb-4">Painel Administrativo</h1>
+  <button onclick="logout()" class="btn btn-secondary mb-3">Sair</button>
+  <form id="user-form">
+    <input type="hidden" id="user-id" />
+    <div class="mb-3">
+      <label class="form-label" for="form-username">Usuário</label>
+      <input class="form-control" id="form-username" required />
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="form-password">Senha</label>
+      <input type="password" class="form-control" id="form-password" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="form-ip">IP liberado (separado por vírgulas)</label>
+      <input class="form-control" id="form-ip" />
+    </div>
+    <button class="btn btn-primary" type="submit">Salvar</button>
+  </form>
+  <hr />
+  <table class="table" id="users-table">
+    <thead>
+      <tr>
+        <th>ID</th><th>Usuário</th><th>IP Liberado</th><th>Ações</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+<script>
+const token = localStorage.getItem('token');
+if(!token){ location.href='/login'; }
+function api(path, options={}){
+  options.headers = options.headers || {};
+  options.headers['Authorization'] = 'Bearer ' + token;
+  if(options.body && !(options.body instanceof FormData)){
+    options.headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify(options.body);
+  }
+  return fetch(path, options);
+}
+function loadUsers(){
+  api('/api/users').then(r=>r.json()).then(data=>{
+    const tbody=document.querySelector('#users-table tbody');
+    tbody.innerHTML='';
+    data.forEach(u=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${u.id}</td><td>${u.username}</td><td>${u.ip_liberado||''}</td><td>
+        <button class="btn btn-sm btn-warning" onclick="editUser(${u.id},'${u.username}','${u.ip_liberado||''}')">Editar</button>
+        <button class="btn btn-sm btn-danger ms-2" onclick="deleteUser(${u.id})">Excluir</button>
+      </td>`;
+      tbody.appendChild(tr);
+    });
+  });
+}
+function editUser(id, username, ip){
+  document.getElementById('user-id').value=id;
+  document.getElementById('form-username').value=username;
+  document.getElementById('form-ip').value=ip;
+}
+document.getElementById('user-form').addEventListener('submit',function(e){
+  e.preventDefault();
+  const id=document.getElementById('user-id').value;
+  const data={username:document.getElementById('form-username').value,
+              password:document.getElementById('form-password').value,
+              ip_liberado:document.getElementById('form-ip').value};
+  const method=id?'PUT':'POST';
+  const url=id?'/api/users/'+id:'/api/users';
+  api(url,{method,body:data}).then(r=>r.json()).then(()=>{this.reset();document.getElementById('user-id').value='';loadUsers();});
+});
+function deleteUser(id){
+  if(confirm('Confirmar exclusão?')){
+    api('/api/users/'+id,{method:'DELETE'}).then(()=>loadUsers());
+  }
+}
+function logout(){
+  localStorage.removeItem('token');
+  location.href='/login';
+}
+loadUsers();
+</script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <script>
+    async function doLogin(evt) {
+      evt.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const resp = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        localStorage.setItem('token', data.access_token);
+        location.href = '/admin';
+      } else {
+        alert(data.erro || 'Falha no login');
+      }
+    }
+  </script>
+</head>
+<body class="container py-5">
+  <h1 class="mb-4">Login</h1>
+  <form onsubmit="doLogin(event)">
+    <div class="mb-3">
+      <label for="username" class="form-label">Usuário</label>
+      <input type="text" class="form-control" id="username" required />
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Senha</label>
+      <input type="password" class="form-control" id="password" required />
+    </div>
+    <button type="submit" class="btn btn-primary">Entrar</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `flask_sqlalchemy` and `flask_jwt_extended` to the project
- configure SQLAlchemy and JWT in `app.py`
- create `User` model and database initialization
- implement `/login` and `/admin` routes with JWT protection
- provide user CRUD API endpoints and templates for login and admin panel

## Testing
- `black .`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fb449bd1c832c9d54e970e9cb100d