### PR TITLE
Secure game APIs with JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Aplicação Flask que consulta o endpoint `https://cgg.bet.br` e exibe em tempo 
 
 Esse mesmo Dockerfile funciona em plataformas como o **EasyPanel**, bastando informar a variável `PORT` caso a hospedagem utilize outra porta padrão.
 
+## Usuário padrão
+
+Ao iniciar a aplicação, é criado automaticamente um usuário administrador.
+As credenciais padrão podem ser definidas pelas variáveis de ambiente
+`ADMIN_USERNAME` e `ADMIN_PASSWORD` (padrão `admin` / `admin`).
+
 ## Scripts disponíveis
 
 - `app.py` – servidor Flask principal.

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,11 @@
     src="{{ url_for('static', filename='script.js') }}"
     defer
   ></script>
+  <script>
+    if (!localStorage.getItem('token')) {
+      window.location.href = '/login';
+    }
+  </script>
 </head>
 <body>
   <div class="container-fluid">

--- a/templates/jogos.html
+++ b/templates/jogos.html
@@ -32,6 +32,9 @@
     {% if modo == 'melhores' %}
     window.IS_MELHORES_PAGE = true;
     {% endif %}
+    if (!localStorage.getItem('token')) {
+      window.location.href = '/login';
+    }
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- create default admin user on startup via ADMIN_USERNAME and ADMIN_PASSWORD
- protect games and winners APIs with JWT
- require token for Socket.IO connections
- send token in requests on the frontend
- refresh best games page with websockets
- document default credentials

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686fc82828d4832cb4d23bc077920798