### PR TITLE
React dashboard integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 image_cache/
 venv/
+game-dashboard/dist/
+game-dashboard/node_modules/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Aplicação Flask que consulta o endpoint `https://cgg.bet.br` e exibe em tempo 
    ```
    O serviço ficará disponível em `http://localhost:5000`.
 
+### Dashboard React
+
+O frontend foi migrado para React e está localizado em `game-dashboard`.
+Para compilar os arquivos de produção:
+
+```bash
+cd game-dashboard
+npm install
+npm run build
+```
+
+Após a construção, o Flask servirá automaticamente o conteúdo da pasta
+`game-dashboard/dist`.
+
 ### Utilizando Docker
 
 1. Construa a imagem:


### PR DESCRIPTION
## Summary
- build React dashboard and serve it from Flask
- update endpoints to use React app for `/`, `/melhores`, `/auth` and `/admin`
- add catch-all route for Vite assets
- document React build process in README
- ignore build output and node modules

## Testing
- `python -m py_compile app.py`
- `black app.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fd6c39d74832cbfeca93e0eef4a15