### PR TITLE
Add unidade display on Melhores page

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -323,6 +323,11 @@ function createGameCard(game, imgUrl, dailyBadge, weeklyBadge, rtpStatus) {
     prioridade.className = 'mb-1';
     prioridade.textContent = game.prioridade || '';
 
+    const unidades = document.createElement('p');
+    unidades.className = 'mb-1 unidades';
+    unidades.textContent =
+        typeof game.extra === 'number' ? `Unidades: ${game.extra}` : '';
+
     const rtpContainer = document.createElement('div');
     rtpContainer.className = 'rtp-container';
 
@@ -350,6 +355,7 @@ function createGameCard(game, imgUrl, dailyBadge, weeklyBadge, rtpStatus) {
     body.appendChild(title);
     body.appendChild(provider);
     if (game.prioridade) body.appendChild(prioridade);
+    if (unidades.textContent) body.appendChild(unidades);
     body.appendChild(rtpContainer);
 
     card.appendChild(img);
@@ -362,6 +368,7 @@ function createGameCard(game, imgUrl, dailyBadge, weeklyBadge, rtpStatus) {
         title,
         provider,
         prioridade,
+        unidades,
         dailyStrong,
         dailyBadgeDiv,
         weeklyStrong,
@@ -409,6 +416,7 @@ function displayGames(games) {
                 title,
                 provider,
                 prioridade,
+                unidades,
                 dailyStrong,
                 dailyBadgeDiv,
                 weeklyStrong,
@@ -422,6 +430,11 @@ function displayGames(games) {
             provider.textContent = `Provedor: ${game.provider.name}`;
             if (prioridade)
                 prioridade.textContent = game.prioridade || '';
+            if (unidades)
+                unidades.textContent =
+                    typeof game.extra === 'number'
+                        ? `Unidades: ${game.extra}`
+                        : '';
             dailyStrong.textContent = `${(game.rtp / 100).toFixed(2)}%`;
             dailyBadgeDiv.innerHTML = dailyBadge;
             const weeklyValue = game.rtp_semana ?? null;

--- a/static/style.css
+++ b/static/style.css
@@ -201,6 +201,11 @@ body {
   text-shadow: 0 0 5px rgba(0,255,180,0.4);
 }
 
+.unidades {
+  font-size: 0.9rem;
+  color: #bbb;
+}
+
 /* Modal drag */
 .modal-draggable .modal-content {
   resize: both;

--- a/templates/melhores.html
+++ b/templates/melhores.html
@@ -48,6 +48,15 @@
         <div id="games-container" class="games-grid"></div>
         <div id="copy-toast" aria-live="polite"></div>
         <audio id="alert-sound" preload="auto"></audio>
+        <div class="bg-dark text-light p-3 rounded mt-4">
+          <h5>Como interpretar as unidades</h5>
+          <p class="mb-0">
+            É totalmente possível descobrir o valor real (negativo) a partir dos
+            números gigantes do tipo <em>Signed</em> usando a conversão de
+            <code>uint64</code> para <code>int64</code>:
+            <code>valor_real = n &gt; 2^63 - 1 ? n - 2^64 : n</code>.
+          </p>
+        </div>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show RTP `unidades` value on game cards
- style unidades label
- explain signed conversion on Melhores page

## Testing
- `black app.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6873b43a0bdc832c898ec50efc203621