### PR TITLE
Add search RTP endpoint and docs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,10 @@
+## Lista de Agentes
+
+- **RTP-CGG**: Servidor Flask que exibe o RTP dos jogos em tempo real.
+
+## Funções e Comportamentos
+
+- `GET /api/games` – retorna jogos consultando `/live-rtp`.
+- `GET /api/melhores` – prioriza jogos por desempenho.
+- `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
+- `GET /api/last-winners` – obtém os últimos vencedores do cassino.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 import urllib3
-from flask import Flask, jsonify, render_template
+from flask import Flask, jsonify, render_template, request
 from flask_socketio import SocketIO, emit
 from flask import send_file, abort
 
@@ -184,6 +184,50 @@ def api_melhores():
     global latest_games
     latest_games = fetch_games_data()
     return jsonify(prioritize_games(latest_games))
+
+
+@app.route("/api/search-rtp", methods=["POST"])
+def search_rtp():
+    search_term = None
+    if request.is_json:
+        search_term = request.json.get("search")
+    if not search_term:
+        search_term = request.form.get("search")
+    if not search_term:
+        return jsonify({"erro": "Consulta inválida"}), 400
+
+    search_url = "https://cbet.gg/casinogo/widgets/v2/live-rtp/search"
+    search_headers = headers.copy()
+    search_headers["accept"] = "application/json"
+    search_headers["content-type"] = "application/json"
+
+    try:
+        if DEBUG_REQUESTS:
+            print("\n[DEBUG] >>> Enviando Requisição de Busca <<<")
+            print(f"[DEBUG] URL: {search_url}")
+            print(f"[DEBUG] Headers: {search_headers}")
+            print(f"[DEBUG] Termo: {search_term}")
+            print(f"[DEBUG] SSL Verify: {VERIFY_SSL}")
+
+        resp = requests.post(
+            search_url,
+            headers=search_headers,
+            json={"search": search_term},
+            verify=VERIFY_SSL,
+        )
+        resp.raise_for_status()
+
+        if DEBUG_REQUESTS:
+            print("\n[DEBUG] <<< Resposta Busca >>>")
+            print(f"[DEBUG] Status Code: {resp.status_code}")
+            print(f"[DEBUG] Conteúdo JSON: {resp.text}\n")
+
+        return jsonify(resp.json())
+    except requests.RequestException as exc:
+        if DEBUG_REQUESTS:
+            print("[DEBUG] Erro na requisição de busca")
+            print(exc)
+        return jsonify({"erro": "Falha ao buscar jogos"}), 500
 
 
 @app.route("/imagens/<int:game_id>.webp")


### PR DESCRIPTION
## Summary
- add `/api/search-rtp` route to query games via cbet search endpoint
- document agent behaviours and endpoints

## Testing
- `python -m py_compile app.py`
- `black app.py --line-length 88`

------
https://chatgpt.com/codex/tasks/task_e_6875296348ac832caeec50eae10b2441