### PR TITLE
Implementa busca por polling e atualização do modal

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -8,3 +8,4 @@
 - `GET /api/melhores` – prioriza jogos por desempenho.
 - `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
 - `GET /api/last-winners` – obtém os últimos vencedores do cassino.
+- A tela de busca utiliza `/api/search-rtp` diretamente e atualiza os dados a cada segundo enquanto houver termo ativo ou um jogo estiver aberto.


### PR DESCRIPTION
## Resumo
- adiciona variáveis para controle de busca e modal
- implementa `fetchAndDisplaySearch` com chamadas a cada segundo
- atualiza `filterAndRender` para ignorar busca local quando pesquisando
- modal de jogo passa a atualizar informações de RTP a cada segundo
- registra em `agents.md` o novo comportamento de busca

## Testes
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68752c885e88832ca5aa2e429a517312