### PR TITLE
Fix search fallback logic

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -6,6 +6,6 @@
 
 - `GET /api/games` – retorna jogos consultando `/live-rtp`.
 - `GET /api/melhores` – prioriza jogos por desempenho.
-- `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
+- `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg e, caso falhe, filtra a lista localmente. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
 - `GET /api/last-winners` – obtém os últimos vencedores do cassino.
 - A tela de busca utiliza `/api/search-rtp` diretamente e atualiza os dados a cada segundo enquanto houver termo ativo ou um jogo estiver aberto.


### PR DESCRIPTION
## Summary
- add local search fallback when remote protobuf lookup fails
- document fallback in agents spec

## Testing
- `black app.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68753157f17c832c940f2b4c69002980