### PR TITLE
Update docs for analytics agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,43 @@ python app.py --insecure
 
 Utilize essa opção apenas em cenários de desenvolvimento ou testes.
 
+
+## Banco de dados SQLite
+
+Para gerar relatórios de RTP é possível armazenar os valores em um banco SQLite.
+Crie o arquivo `analytics.db` executando o script abaixo:
+
+```bash
+sqlite3 analytics.db <<SQL
+CREATE TABLE IF NOT EXISTS history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id INTEGER NOT NULL,
+  rtp REAL NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+SQL
+```
+
+## Habilitar página de analytics
+
+A página `/analytics` fica desabilitada por padrão. Defina a variável
+`ENABLE_ANALYTICS=true` antes de iniciar o servidor para ativá-la:
+
+```bash
+ENABLE_ANALYTICS=true python app.py
+```
+
+### Consultar histórico
+
+O endpoint `/api/history` retorna os registros gravados no banco.
+
+Exemplos de uso:
+
+```bash
+# Últimos 50 registros
+curl http://localhost:5000/api/history?limit=50
+
+# Filtrar por jogo específico
+curl http://localhost:5000/api/history?game_id=1024
+```
+

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,7 @@
 ## Lista de Agentes
 
 - **RTP-CGG**: Servidor Flask que exibe o RTP dos jogos em tempo real.
+- **Analytics**: Registra o histórico de RTP no banco SQLite para exibição na página de analytics.
 
 ## Funções e Comportamentos
 
@@ -8,4 +9,9 @@
 - `GET /api/melhores` – prioriza jogos por desempenho.
 - `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg e, caso falhe, filtra a lista localmente. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
 - `GET /api/last-winners` – obtém os últimos vencedores do cassino.
+- `GET /api/history` – recupera registros da tabela `history` em `analytics.db`.
 - A tela de busca utiliza `/api/search-rtp` diretamente e atualiza os dados a cada segundo enquanto houver termo ativo ou um jogo estiver aberto.
+
+### Permissões
+
+O agente de analytics precisa de permissão de leitura e escrita no arquivo `analytics.db`.


### PR DESCRIPTION
## Summary
- document analytics database and history endpoint usage
- detail new analytics agent and its permissions

## Testing
- `python -m py_compile app.py`
- `black app.py`

------
https://chatgpt.com/codex/tasks/task_e_6877210ddb60832cbb246fb3d327028b