### PR TITLE
Update API endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RTP-CGG
 
-Aplicação Flask que consulta o endpoint `https://cgg.bet.br` e exibe em tempo real o RTP (Return to Player) dos jogos de cassino.
+Aplicação Flask que consulta o endpoint `https://cbet.gg` e exibe em tempo real o RTP (Return to Player) dos jogos de cassino.
 
 ## Pré-requisitos
 


### PR DESCRIPTION
## Summary
- update endpoint URL to cbet.gg in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687722bf68b8832cad17a690b1552fd6