### PR TITLE
Reduce repeated search polling

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -12,7 +12,7 @@ Para instruções de configuração e diretrizes de contribuição, consulte o a
 - `POST /api/search-rtp` – pesquisa jogos enviando ao endpoint `/live-rtp/search` do site cbet.gg e, caso falhe, filtra a lista localmente. Utiliza headers `accept`, `content-type`, `x-language-iso`, `origin` e `referer`. A requisição respeita a variável `VERIFY_SSL` para definir se o certificado TLS será verificado.
 - `GET /api/last-winners` – obtém os últimos vencedores do cassino.
 - `GET /api/history` – recupera registros da tabela `history` em `analytics.db`.
-- A tela de busca utiliza `/api/search-rtp` diretamente e atualiza os dados a cada segundo enquanto houver termo ativo ou um jogo estiver aberto.
+- A tela de busca utiliza `/api/search-rtp` diretamente, atualizando os dados após a pesquisa e tentando novamente após alguns segundos quando necessário.
 
 - A interface possui filtros `min-extra` e `max-extra` para limitar a listagem pelos valores de `extra`.
 - Os campos `alert-extra-pos` e `alert-extra-neg` tocam um som quando qualquer jogo ultrapassa os limites configurados.

--- a/static/script.js
+++ b/static/script.js
@@ -10,7 +10,7 @@ let gameModal;
 let modalGameId = null;
 let socket;
 let socketGames = [];
-let searchInterval = null;
+let searchTimeout;
 let isSearching = false;
 let currentQuery = '';
 let modalInterval = null;
@@ -650,7 +650,7 @@ function filterAndRender() {
 
 const handleSearchInput = debounce(async () => {
     const termo = document.getElementById('search-input')?.value.trim();
-    clearInterval(searchInterval);
+    clearTimeout(searchTimeout);
     isSearching = !!termo;
     currentQuery = termo || '';
     if (isSearching) {
@@ -662,9 +662,9 @@ const handleSearchInput = debounce(async () => {
             filterAndRender();
         } else {
             await fetchAndDisplaySearch(currentQuery);
-            searchInterval = setInterval(
+            searchTimeout = setTimeout(
                 () => fetchAndDisplaySearch(currentQuery),
-                1000
+                5000
             );
         }
     } else {


### PR DESCRIPTION
## Summary
- use a timeout for search instead of interval
- document the new search behaviour

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687722c1b544832cbd2ba9040e2ba818