### PR TITLE
Clarify guideline file roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+> **Escopo:** este documento descreve as regras de instalação, desenvolvimento e verificação do projeto. As informações sobre agentes e integrações estão em `agents.md`.
+
 Consulte o arquivo `agents.md` para detalhes sobre os agentes da aplicação. Atualize este documento apenas com diretrizes de configuração e desenvolvimento do repositório.
 
 ## Setup

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
 ## Lista de Agentes
 
-Para instruções de configuração e diretrizes de contribuição, consulte o arquivo `AGENTS.md`.
+> **Escopo:** este documento descreve os agentes e integrações do projeto, incluindo permissões e comportamentos. Para diretrizes de instalação e contribuição, consulte `AGENTS.md`.
 
 - **RTP-CGG**: Servidor Flask que exibe o RTP dos jogos em tempo real.
 - **Analytics**: Registra o histórico de RTP no banco SQLite para exibição na página de analytics.


### PR DESCRIPTION
## Summary
- make AGENTS.md clarify that it holds repository guidelines
- make agents.md clarify that it lists automation agents

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687726263e24832c9e4f8f13d2b8dbeb