### PR TITLE
feat: filter history by game

### DIFF
--- a/app.py
+++ b/app.py
@@ -263,8 +263,14 @@ def api_melhores():
 @app.route("/api/history")
 def api_history():
     period = request.args.get("period", "daily")
+    game_id = request.args.get("game_id")
+    name = request.args.get("name")
     try:
-        return jsonify(db.query_history(period))
+        gid = int(game_id) if game_id is not None else None
+    except ValueError:
+        return jsonify([]), 400
+    try:
+        return jsonify(db.query_history(period, game_id=gid, name=name))
     except ValueError:
         return jsonify([]), 400
 

--- a/templates/historico.html
+++ b/templates/historico.html
@@ -38,14 +38,21 @@
   <script>
     document.getElementById('btn-search').addEventListener('click', loadHistory);
     async function loadHistory() {
-      const name = document.getElementById('search-name').value.toLowerCase();
+      const search = document.getElementById('search-name').value.trim();
       const period = document.getElementById('period').value;
-      const resp = await fetch(`/api/history?period=${period}`);
+      let url = `/api/history?period=${period}`;
+      if (search) {
+        if (/^\d+$/.test(search)) {
+          url += `&game_id=${encodeURIComponent(search)}`;
+        } else {
+          url += `&name=${encodeURIComponent(search)}`;
+        }
+      }
+      const resp = await fetch(url);
       if (!resp.ok) return;
       const data = await resp.json();
-      const filtered = name ? data.filter(d => d.name.toLowerCase().includes(name)) : data;
-      renderTable(filtered);
-      renderChart(filtered);
+      renderTable(data);
+      renderChart(data);
     }
     function renderTable(rows) {
       const tbody = document.querySelector('#history-table tbody');


### PR DESCRIPTION
## Summary
- allow query_history to filter by `game_id` or name
- read these params in `/api/history`
- pass filters from Historico page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68772625e168832cbceb6df6029abada