### PR TITLE
Adiciona tela de histórico em grade

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,6 +261,12 @@ def historico():
     return render_template("historico.html")
 
 
+@app.route("/historico-registros")
+def historico_registros():
+    """Página de histórico em formato de grade."""
+    return render_template("historico_grid.html")
+
+
 @app.route("/api/games")
 def games():
     global latest_games
@@ -302,6 +308,16 @@ def api_game_history():
     if gid is None:
         return jsonify([]), 400
     return jsonify(db.game_history(gid))
+
+
+@app.route("/api/history/records")
+def api_history_records():
+    """Retorna registros brutos do historico."""
+    start = request.args.get("start")
+    end = request.args.get("end")
+    gid = request.args.get("game_id", type=int)
+    name = request.args.get("name")
+    return jsonify(db.history_records(start, end, gid, name))
 
 
 @app.route("/api/search-rtp", methods=["POST"])

--- a/templates/historico_grid.html
+++ b/templates/historico_grid.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>📑 Histórico Completo</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+</head>
+<body>
+  <div class="container py-3">
+    <div class="mb-3 row g-2">
+      <div class="col-md-2">
+        <input type="date" id="start" class="form-control" />
+      </div>
+      <div class="col-md-2">
+        <input type="date" id="end" class="form-control" />
+      </div>
+      <div class="col-md-2">
+        <input type="number" id="game-id" class="form-control" placeholder="ID do jogo" />
+      </div>
+      <div class="col-md-3">
+        <input type="text" id="name" class="form-control" placeholder="Nome do jogo" />
+      </div>
+      <div class="col-md-3 text-end">
+        <button id="btn-filtrar" class="btn btn-success">Filtrar</button>
+        <a href="/" class="btn btn-secondary">Voltar</a>
+      </div>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-dark table-striped" id="records-table">
+        <thead>
+          <tr>
+            <th>Data</th>
+            <th>ID</th>
+            <th>Jogo</th>
+            <th>RTP (%)</th>
+            <th>Unidades</th>
+            <th>Provedor</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <script>
+    document.getElementById('btn-filtrar').addEventListener('click', carregar);
+    document.addEventListener('DOMContentLoaded', carregar);
+
+    async function carregar() {
+      const params = new URLSearchParams();
+      const inicio = document.getElementById('start').value;
+      const fim = document.getElementById('end').value;
+      const gid = document.getElementById('game-id').value;
+      const nome = document.getElementById('name').value;
+      if (inicio) params.append('start', inicio);
+      if (fim) params.append('end', fim);
+      if (gid) params.append('game_id', gid);
+      if (nome) params.append('name', nome);
+      const resp = await fetch('/api/history/records?' + params.toString());
+      if (!resp.ok) return;
+      const dados = await resp.json();
+      const tbody = document.querySelector('#records-table tbody');
+      tbody.innerHTML = '';
+      for (const row of dados) {
+        const tr = document.createElement('tr');
+        const data = new Date(row.timestamp).toLocaleString();
+        tr.innerHTML = `<td>${data}</td><td>${row.game_id}</td><td>${row.name}</td>` +
+          `<td>${(Number(row.rtp) / 100).toFixed(2)}</td><td>${row.extra}</td><td>${row.provider}</td>`;
+        tbody.appendChild(tr);
+      }
+    }
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -146,6 +146,7 @@
           </button>
           <a href="/melhores" class="btn btn-primary w-100 mt-2">🎯 Melhores Jogos</a>
           <a href="/historico" class="btn btn-secondary w-100 mt-2">📊 Histórico</a>
+          <a href="/historico-registros" class="btn btn-secondary w-100 mt-2">🗂️ Registros</a>
         </div>
       </aside>
 


### PR DESCRIPTION
## Summary
- implement function `history_records` em `db.py`
- criar rota `/api/history/records` em `app.py`
- adicionar página `/historico-registros` exibindo grade com filtros
- linkar página nova na home

## Testing
- `black app.py db.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68773534377c832eb77e3e7a2ad4db34