### PR TITLE
Fix decode_signed boundary check

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ latest_games = []
 
 
 def decode_signed(value):
-    if value > (1 << 63):
+    if value >= (1 << 63):
         value -= 1 << 64
     return value
 


### PR DESCRIPTION
## Summary
- correct signed decoding logic to handle 2**63

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68779e6f91d4832c8852f628d6857a24