### PR TITLE
Fix search updates and document behavior

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -18,6 +18,7 @@
 - `GET /api/last-winners` – obtém os últimos vencedores do cassino.
 - `GET /api/history` – recupera registros da tabela `rtp_history` no banco definido em `DATABASE_URL`.
 - A tela de busca utiliza `/api/search-rtp` diretamente, atualizando os dados após a pesquisa e tentando novamente após alguns segundos quando necessário.
+- Durante uma busca, os jogos exibidos também recebem atualizações em tempo real quando disponíveis pelo websocket.
 
 - A interface possui filtros `min-extra` e `max-extra` para limitar a listagem pelos valores de `extra`.
 - Os campos `alert-extra-pos` e `alert-extra-neg` tocam um som quando qualquer jogo ultrapassa os limites configurados.

--- a/static/script.js
+++ b/static/script.js
@@ -172,7 +172,10 @@ function checkUnidadesAlerts() {
 function handleGamesData(data) {
     const processed = window.IS_MELHORES_PAGE ? applyPriorities(data) : data;
     socketGames = processed;
-    if (!isSearching) {
+    if (isSearching && gamesData.length) {
+        const map = new Map(processed.map(g => [g.id, g]));
+        gamesData = gamesData.map(g => map.get(g.id) || g);
+    } else if (!isSearching) {
         gamesData = processed;
     }
     alerts.forEach(alert => {


### PR DESCRIPTION
## Summary
- keep search results updated with websocket data
- document that search results receive realtime updates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6877a5bec3fc832ca609da84f7bfc152