### PR TITLE
Support multi-casa data

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,8 @@ import db
 app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins="*")
 
+CASAS = {"cbet": "https://cbet.gg", "cgg": "https://cgg.bet"}
+
 DEBUG_REQUESTS = os.environ.get("DEBUG_REQUESTS", "false").lower() in (
     "1",
     "true",
@@ -32,20 +34,28 @@ VERIFY_SSL = os.environ.get("VERIFY_SSL", "true").lower() not in (
 )
 REQUEST_TIMEOUT = 10
 
-url = "https://cbet.gg/casinogo/widgets/v2/live-rtp"
-search_url = "https://cbet.gg/casinogo/widgets/v2/live-rtp/search"
-headers = {
+HEADERS_TEMPLATE = {
     "accept": "application/x-protobuf",
     "content-type": "application/x-protobuf",
     "accept-language": "pt-BR",
     "user-agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) "
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0 "
         "Gecko/20100101 Firefox/140.0"
     ),
     "x-language-iso": "pt-BR",
-    "origin": "https://cbet.gg",
-    "referer": "https://cbet.gg/pt-BR/casinos/casino/lobby",
 }
+
+
+def build_urls_headers(casa: str):
+    base = CASAS.get(casa, CASAS["cbet"])
+    url = f"{base}/casinogo/widgets/v2/live-rtp"
+    search_url = f"{base}/casinogo/widgets/v2/live-rtp/search"
+    headers = HEADERS_TEMPLATE.copy()
+    headers["origin"] = base
+    headers["referer"] = f"{base}/pt-BR/casinos/casino/lobby"
+    return url, search_url, headers
+
+
 data = b"\x08\x01\x10\x02"
 data_weekly = b"\x08\x02\x10\x02"
 
@@ -86,7 +96,7 @@ def get_protobuf_message():
 
 ProtobufMessage = get_protobuf_message()
 
-latest_games = []
+latest_games = {"cbet": [], "cgg": []}
 
 
 def decode_signed(value):
@@ -123,7 +133,8 @@ def has_changes(novos, antigos):
     return False
 
 
-def fetch_games_data():
+def fetch_games_data(casa: str = "cbet"):
+    url, _, headers = build_urls_headers(casa)
     if DEBUG_REQUESTS:
         print("\n[DEBUG] >>> Enviando Requisição <<<")
         print(f"[DEBUG] URL: {url}")
@@ -192,11 +203,12 @@ def fetch_games_data():
     return games
 
 
-def fetch_games_by_name(names: list[str]):
+def fetch_games_by_name(names: list[str], casa: str = "cbet"):
     results = []
     for name in names:
         body = b"\x02\x10\x19\x12" + len(name).to_bytes(1, "little") + name.encode()
 
+        url, search_url, headers = build_urls_headers(casa)
         if DEBUG_REQUESTS:
             print("\n[DEBUG] >>> Enviando Busca RTP <<<")
             print(f"[DEBUG] URL: {search_url}")
@@ -238,47 +250,60 @@ def fetch_games_by_name(names: list[str]):
     return results
 
 
-def search_local(names: list[str]):
+def search_local(names: list[str], casa: str = "cbet"):
     queries = [str(n).lower() for n in names]
     global latest_games
-    if not latest_games:
-        latest_games = fetch_games_data()
-    return [g for g in latest_games if any(q in g["name"].lower() for q in queries)]
+    if not latest_games[casa]:
+        latest_games[casa] = fetch_games_data(casa)
+    return [
+        g for g in latest_games[casa] if any(q in g["name"].lower() for q in queries)
+    ]
 
 
 @app.route("/")
+@app.route("/cbet")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", house="cbet")
+
+
+@app.route("/cgg")
+def index_cgg():
+    return render_template("index.html", house="cgg")
 
 
 @app.route("/melhores")
 def melhores():
-    return render_template("melhores.html")
+    casa = request.args.get("casa", "cbet")
+    return render_template("melhores.html", house=casa)
 
 
 @app.route("/historico")
 def historico():
-    return render_template("historico.html")
+    casa = request.args.get("casa", "cbet")
+    return render_template("historico.html", house=casa)
 
 
 @app.route("/historico-registros")
 def historico_registros():
     """Página de histórico em formato de grade."""
-    return render_template("historico_grid.html")
+    casa = request.args.get("casa", "cbet")
+    return render_template("historico_grid.html", house=casa)
 
 
 @app.route("/api/games")
-def games():
+@app.route("/api/games/<casa>")
+def games(casa="cbet"):
     global latest_games
-    latest_games = fetch_games_data()
-    return jsonify(latest_games)
+    latest_games[casa] = fetch_games_data(casa)
+    return jsonify(latest_games[casa])
 
 
 @app.route("/api/melhores")
-def api_melhores():
+@app.route("/api/melhores/<casa>")
+def api_melhores(casa="cbet"):
     global latest_games
-    latest_games = fetch_games_data()
-    return jsonify(prioritize_games(latest_games))
+    latest_games[casa] = fetch_games_data(casa)
+    return jsonify(prioritize_games(latest_games[casa]))
 
 
 @app.route("/api/history")
@@ -286,12 +311,13 @@ def api_history():
     period = request.args.get("period", "daily")
     game_id = request.args.get("game_id")
     name = request.args.get("name")
+    casa = request.args.get("casa")
     try:
         gid = int(game_id) if game_id is not None else None
     except ValueError:
         return jsonify([]), 400
     try:
-        return jsonify(db.query_history(period, game_id=gid, name=name))
+        return jsonify(db.query_history(period, game_id=gid, name=name, casa=casa))
     except ValueError:
         return jsonify([]), 400
 
@@ -299,7 +325,8 @@ def api_history():
 @app.route("/api/history/games")
 def api_history_games():
     """Lista jogos disponíveis no histórico."""
-    return jsonify(db.list_games())
+    casa = request.args.get("casa")
+    return jsonify(db.list_games(casa))
 
 
 @app.route("/api/game-history")
@@ -307,7 +334,8 @@ def api_game_history():
     gid = request.args.get("game_id", type=int)
     if gid is None:
         return jsonify([]), 400
-    return jsonify(db.game_history(gid))
+    casa = request.args.get("casa")
+    return jsonify(db.game_history(gid, casa))
 
 
 @app.route("/api/history/records")
@@ -317,18 +345,20 @@ def api_history_records():
     end = request.args.get("end")
     gid = request.args.get("game_id")
     name = request.args.get("name")
-    return jsonify(db.history_records(start, end, gid, name))
+    casa = request.args.get("casa")
+    return jsonify(db.history_records(start, end, gid, name, casa))
 
 
 @app.route("/api/search-rtp", methods=["POST"])
-def api_search_rtp():
+@app.route("/api/search-rtp/<casa>", methods=["POST"])
+def api_search_rtp(casa="cbet"):
     try:
         names = request.get_json(force=True).get("names", [])
         if not isinstance(names, list):
             return jsonify([])
-        games = fetch_games_by_name([str(n) for n in names])
+        games = fetch_games_by_name([str(n) for n in names], casa)
         if not games:
-            games = search_local(names)
+            games = search_local(names, casa)
         return jsonify(games)
     except Exception as exc:
         if DEBUG_REQUESTS:
@@ -339,9 +369,11 @@ def api_search_rtp():
 
 @app.route("/imagens/<int:game_id>.webp")
 def cached_image(game_id):
+    casa = request.args.get("casa", "cbet")
     file_path = os.path.join(IMAGE_CACHE_DIR, f"{game_id}.webp")
     if not os.path.exists(file_path):
-        remote_url = f"https://cbet.gg/static/v1/casino/game/0/{game_id}/big.webp"
+        base = CASAS.get(casa, CASAS["cbet"])
+        remote_url = f"{base}/static/v1/casino/game/0/{game_id}/big.webp"
         try:
             resp = requests.get(remote_url, verify=VERIFY_SSL, timeout=10)
             resp.raise_for_status()
@@ -360,27 +392,31 @@ def cached_image(game_id):
 
 @socketio.on("connect")
 def handle_connect():
-    if latest_games:
-        emit("games_update", latest_games)
+    for casa, games in latest_games.items():
+        if games:
+            emit("games_update", {"casa": casa, "games": games})
 
 
 def background_fetch():
     global latest_games
     while True:
         try:
-            novos = fetch_games_data()
-            if has_changes(novos, latest_games):
-                latest_games = novos
-                db.insert_games(latest_games)
-                socketio.emit("games_update", latest_games)
+            for casa in CASAS:
+                novos = fetch_games_data(casa)
+                if has_changes(novos, latest_games[casa]):
+                    latest_games[casa] = novos
+                    db.insert_games(novos, casa)
+                    socketio.emit("games_update", {"casa": casa, "games": novos})
         finally:
             socketio.sleep(3)
 
 
 @app.route("/api/last-winners")
-def last_winners():
-    winners_url = "https://cbet.gg/casinogo/widgets/last-winners"
-    winners_headers = headers.copy()
+@app.route("/api/last-winners/<casa>")
+def last_winners(casa="cbet"):
+    base = CASAS.get(casa, CASAS["cbet"])
+    winners_url = f"{base}/casinogo/widgets/last-winners"
+    _, _, winners_headers = build_urls_headers(casa)
     winners_headers["accept"] = "application/json"
 
     try:

--- a/schema.sql
+++ b/schema.sql
@@ -5,5 +5,6 @@ CREATE TABLE IF NOT EXISTS rtp_history (
     rtp REAL,
     extra BIGINT,
     rtp_status TEXT,
+    casa TEXT,
     timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );

--- a/static/script.js
+++ b/static/script.js
@@ -214,7 +214,7 @@ async function fetchGames(showSpinner = false) {
 
     try {
         if (spinner && showSpinner) spinner.classList.remove('d-none');
-        const response = await fetch('/api/games');
+        const response = await fetch(`/api/games/${window.HOUSE}`);
         if (!response.ok) throw new Error('Erro na resposta da rede');
 
         const data = await response.json();
@@ -240,7 +240,7 @@ async function fetchMelhores(showSpinner = false) {
 
     try {
         if (spinner && showSpinner) spinner.classList.remove('d-none');
-        const response = await fetch('/api/melhores');
+        const response = await fetch(`/api/melhores/${window.HOUSE}`);
         if (!response.ok) throw new Error('Erro na resposta da rede');
         const data = await response.json();
         handleGamesData(data);
@@ -260,7 +260,7 @@ async function fetchMelhores(showSpinner = false) {
 
 async function fetchRtpAtual(nome) {
     try {
-        const resposta = await fetch('/api/search-rtp', {
+        const resposta = await fetch(`/api/search-rtp/${window.HOUSE}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ names: [nome] }),
@@ -287,7 +287,7 @@ async function fetchAndDisplaySearch(query) {
 
 async function fetchWinners() {
     try {
-        const res = await fetch("/api/last-winners");
+        const res = await fetch(`/api/last-winners/${window.HOUSE}`);
         if (!res.ok) throw new Error("Falha na rede");
         const data = await res.json();
         const winners = Array.isArray(data) ? data : data.items || [];
@@ -315,7 +315,11 @@ async function fetchWinners() {
 
 function connectSocket() {
     socket = io();
-    socket.on('games_update', data => handleGamesData(data));
+    socket.on('games_update', payload => {
+        if (payload.casa === window.HOUSE) {
+            handleGamesData(payload.games);
+        }
+    });
 }
 
 
@@ -323,7 +327,7 @@ function fillGameModal(game) {
     document.getElementById('gameModalLabel').textContent = game.name;
     const imgEl = document.getElementById('gameModalImg');
     if (imgEl) {
-        imgEl.src = `${IMAGE_ENDPOINT}/${game.id}.webp`;
+        imgEl.src = `${IMAGE_ENDPOINT}/${game.id}.webp?casa=${window.HOUSE}`;
         imgEl.alt = `Imagem de ${game.name}`;
     }
     const provEl = document.getElementById('gameModalProvider');
@@ -513,7 +517,7 @@ function displayGames(games) {
 
     games.forEach(game => {
         present.add(game.id);
-        const imgUrl = `${IMAGE_ENDPOINT}/${game.id}.webp`;
+        const imgUrl = `${IMAGE_ENDPOINT}/${game.id}.webp?casa=${window.HOUSE}`;
         const rtpStatus = game.rtp_status || 'neutral';
         const dailyBadge = {
             down: '<span class="badge bg-danger rtp-badge">▼ Dia</span>',

--- a/templates/historico.html
+++ b/templates/historico.html
@@ -8,10 +8,15 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <script>window.HOUSE="{{ house }}"</script>
 </head>
 <body>
   <div class="container py-3">
     <div class="mb-3 d-flex gap-2">
+      <select id="casa-select" class="form-select">
+        <option value="cbet">cbet</option>
+        <option value="cgg">cgg</option>
+      </select>
       <select id="game-select" class="form-select"></select>
       <a href="/" class="btn btn-secondary">Voltar</a>
     </div>
@@ -31,12 +36,18 @@
   <script>
     document.addEventListener('DOMContentLoaded', init);
     async function init() {
+      const casaSel = document.getElementById('casa-select');
+      casaSel.value = window.HOUSE;
+      casaSel.addEventListener('change', () => {
+        window.HOUSE = casaSel.value;
+        loadGames();
+      });
       await loadGames();
       document.getElementById('game-select').addEventListener('change', loadHistory);
     }
 
     async function loadGames() {
-      const resp = await fetch('/api/history/games');
+      const resp = await fetch(`/api/history/games?casa=${window.HOUSE}`);
       if (!resp.ok) return;
       const games = await resp.json();
       const select = document.getElementById('game-select');
@@ -56,7 +67,7 @@
     async function loadHistory() {
       const gid = document.getElementById('game-select').value;
       if (!gid) return;
-      const resp = await fetch(`/api/game-history?game_id=${gid}`);
+      const resp = await fetch(`/api/game-history?game_id=${gid}&casa=${window.HOUSE}`);
       if (!resp.ok) return;
       const data = await resp.json();
       renderTable(data);

--- a/templates/historico_grid.html
+++ b/templates/historico_grid.html
@@ -7,10 +7,17 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script>window.HOUSE="{{ house }}"</script>
 </head>
 <body>
   <div class="container py-3">
     <div class="mb-3 row g-2">
+      <div class="col-md-2">
+        <select id="casa" class="form-select">
+          <option value="cbet">cbet</option>
+          <option value="cgg">cgg</option>
+        </select>
+      </div>
       <div class="col-md-2">
         <input type="date" id="start" class="form-control" />
       </div>
@@ -47,7 +54,12 @@
   </div>
   <script>
     document.getElementById('btn-filtrar').addEventListener('click', carregar);
-    document.addEventListener('DOMContentLoaded', carregar);
+    document.addEventListener('DOMContentLoaded', () => {
+      const sel = document.getElementById('casa');
+      sel.value = window.HOUSE;
+      sel.addEventListener('change', carregar);
+      carregar();
+    });
 
     async function carregar() {
       const params = new URLSearchParams();
@@ -59,6 +71,7 @@
       if (fim) params.append('end', fim);
       if (gidValue) params.append('game_id', gidValue);
       if (nome) params.append('name', nome);
+      params.append('casa', document.getElementById('casa').value);
       const resp = await fetch('/api/history/records?' + params.toString());
       if (!resp.ok) return;
       const dados = await resp.json();

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
     src="{{ url_for('static', filename='script.js') }}"
     defer
   ></script>
+  <script>window.HOUSE="{{ house }}"</script>
 </head>
 <body>
   <div class="container-fluid">

--- a/templates/melhores.html
+++ b/templates/melhores.html
@@ -10,6 +10,7 @@
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script src="{{ url_for('static', filename='script.js') }}" defer></script>
   <script>window.IS_MELHORES_PAGE = true;</script>
+  <script>window.HOUSE="{{ house }}"</script>
 
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow selecting cbet or cgg casino
- store casa in database and queries
- update API endpoints and websocket messages
- pass selected casa to frontend templates
- update JS to use the selected house

## Testing
- `black app.py db.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6879344c9b44832e95d168d9be2b3eb6