### PR TITLE
Keep house selection across pages

### DIFF
--- a/templates/historico.html
+++ b/templates/historico.html
@@ -18,7 +18,11 @@
         <option value="cgg">cgg</option>
       </select>
       <select id="game-select" class="form-select"></select>
+      {% if house == 'cgg' %}
+      <a href="/cgg" class="btn btn-secondary">Voltar</a>
+      {% else %}
       <a href="/" class="btn btn-secondary">Voltar</a>
+      {% endif %}
     </div>
     <canvas id="chart" class="mb-4"></canvas>
     <table class="table table-dark table-striped" id="history-table">

--- a/templates/historico_grid.html
+++ b/templates/historico_grid.html
@@ -32,7 +32,11 @@
       </div>
       <div class="col-md-3 text-end">
         <button id="btn-filtrar" class="btn btn-success">Filtrar</button>
+        {% if house == 'cgg' %}
+        <a href="/cgg" class="btn btn-secondary">Voltar</a>
+        {% else %}
         <a href="/" class="btn btn-secondary">Voltar</a>
+        {% endif %}
       </div>
     </div>
     <div class="table-responsive">

--- a/templates/index.html
+++ b/templates/index.html
@@ -145,9 +145,9 @@
           <button class="btn btn-warning w-100" onclick="fetchGames(true)">
             🔄 Atualizar Agora
           </button>
-          <a href="/melhores" class="btn btn-primary w-100 mt-2">🎯 Melhores Jogos</a>
-          <a href="/historico" class="btn btn-secondary w-100 mt-2">📊 Histórico</a>
-          <a href="/historico-registros" class="btn btn-secondary w-100 mt-2">🗂️ Registros</a>
+          <a href="/melhores?casa={{ house }}" class="btn btn-primary w-100 mt-2">🎯 Melhores Jogos</a>
+          <a href="/historico?casa={{ house }}" class="btn btn-secondary w-100 mt-2">📊 Histórico</a>
+          <a href="/historico-registros?casa={{ house }}" class="btn btn-secondary w-100 mt-2">🗂️ Registros</a>
         </div>
       </aside>
 

--- a/templates/melhores.html
+++ b/templates/melhores.html
@@ -40,7 +40,11 @@
           <button class="btn btn-info w-100 mb-2" onclick="sortBy('name')">🔤 Ordenar por Nome</button>
 
           <button class="btn btn-warning w-100" onclick="fetchGames(true)">🔄 Atualizar Agora</button>
+          {% if house == 'cgg' %}
+          <a href="/cgg" class="btn btn-secondary w-100 mt-2">↩️ Voltar</a>
+          {% else %}
           <a href="/" class="btn btn-secondary w-100 mt-2">↩️ Voltar</a>
+          {% endif %}
         </div>
       </aside>
       <main class="col-md-9 col-lg-10">


### PR DESCRIPTION
## Summary
- add house parameter to navigation links so each page shows data from only one casino
- show proper back link for cgg/cbet

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68793987ac48832e8a0b9011547d5f85