### PR TITLE
Enable eventlet for websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Aplicação Flask que consulta o endpoint `https://cbet.gg.br` e exibe em tempo 
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Inicie o servidor Flask:
+2. Inicie o servidor Flask com suporte a WebSocket:
    ```bash
    python app.py
    ```
-   O serviço ficará disponível em `http://localhost:5000`.
+   Não utilize `flask run`, pois o websocket requer que o servidor do
+   `Flask-SocketIO` seja iniciado. O serviço ficará disponível em
+   `http://localhost:5000`.
 
 ### Utilizando Docker
 
@@ -33,7 +35,11 @@ Aplicação Flask que consulta o endpoint `https://cbet.gg.br` e exibe em tempo 
    ```bash
    docker run -e PORT=5000 -p 5000:5000 rtp-cgg
    ```
-3. Acesse `http://localhost:5000` para visualizar o dashboard.
+3. Acesse `http://localhost:5000` para visualizar o dashboard. Em
+   produção, execute o servidor com:
+   ```bash
+   gunicorn -k eventlet -b 0.0.0.0:5000 wsgi:app
+   ```
 
 Esse mesmo Dockerfile funciona em plataformas como o **EasyPanel**, bastando informar a variável `PORT` caso a hospedagem utilize outra porta padrão.
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import os
 import urllib3
+import eventlet
+eventlet.monkey_patch()
 from flask import Flask, jsonify, render_template, request
 from flask_socketio import SocketIO, emit
 from flask import send_file, abort
@@ -14,7 +16,7 @@ from google.protobuf.json_format import MessageToDict
 import db
 
 app = Flask(__name__)
-socketio = SocketIO(app, cors_allowed_origins="*")
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
 CASAS = {"cbet": "https://cbet.gg.br", "cgg": "https://cgg.bet"}
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,3 +1,5 @@
+import eventlet
+eventlet.monkey_patch()
 from app import app, socketio, background_fetch
 
 socketio.start_background_task(background_fetch)


### PR DESCRIPTION
## Summary
- enable eventlet monkey patching and configure SocketIO to use eventlet
- patch wsgi.py to monkey patch for gunicorn
- document correct server startup in README

## Testing
- `python -m py_compile app.py wsgi.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_687943ec4b18832ea742042d30f393d6