### PR TITLE
Add casa column to rtp_history

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ psql "$DATABASE_URL" -c "ALTER TABLE rtp_history ALTER COLUMN game_id TYPE BIGIN
 psql "$DATABASE_URL" -c "ALTER TABLE rtp_history ALTER COLUMN extra TYPE BIGINT"
 psql "$DATABASE_URL" -c "ALTER TABLE rtp_history ADD COLUMN rtp_status TEXT"
 psql "$DATABASE_URL" -c "UPDATE rtp_history SET rtp_status = CASE WHEN extra IS NULL THEN 'neutral' WHEN extra < 0 THEN 'down' ELSE 'up' END"
+psql "$DATABASE_URL" -c "ALTER TABLE rtp_history ADD COLUMN casa TEXT DEFAULT 'cbet'"
+psql "$DATABASE_URL" -c "UPDATE rtp_history SET casa = 'cbet'"
 ```
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -5,5 +5,6 @@ CREATE TABLE IF NOT EXISTS rtp_history (
     rtp REAL,
     extra BIGINT,
     rtp_status TEXT,
+    casa TEXT DEFAULT 'cbet',
     timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- add `casa` column with default `cbet`
- include `casa` column when inserting games
- document SQL commands to add the column for existing DBs

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687956fd19f8832ea57b77d7bed2536a