### PR TITLE
Add registro-extra page with avg extra filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -267,6 +267,12 @@ def historico_registros():
     return render_template("historico_grid.html")
 
 
+@app.route("/registro-extra")
+def registro_extra():
+    """Página que exibe jogos filtrados pela média de unidades."""
+    return render_template("registro_extra.html")
+
+
 @app.route("/api/games")
 def games():
     global latest_games
@@ -318,6 +324,17 @@ def api_history_records():
     gid = request.args.get("game_id")
     name = request.args.get("name")
     return jsonify(db.history_records(start, end, gid, name))
+
+
+@app.route("/api/registro-extra")
+def api_registro_extra():
+    """Retorna jogos filtrados pela média de unidades."""
+    start = request.args.get("dataInicial")
+    end = request.args.get("dataFinal")
+    extra = request.args.get("extra", type=int)
+    if not start or not end or extra is None:
+        return jsonify([]), 400
+    return jsonify(db.games_by_extra(start, end, extra))
 
 
 @app.route("/api/search-rtp", methods=["POST"])

--- a/db.py
+++ b/db.py
@@ -211,4 +211,27 @@ def history_records(
         return cur.fetchall()
 
 
+def games_by_extra(
+    start: str,
+    end: str,
+    extra: int,
+    casa: str = "cbet",
+) -> list[dict]:
+    """Retorna jogos filtrados pela média de unidades no período."""
+    op = ">" if extra >= 0 else "<"
+    order = "DESC" if extra >= 0 else "ASC"
+    query = f"""
+        SELECT game_id, name, provider, AVG(extra) AS media
+        FROM rtp_history
+        WHERE casa = %s AND timestamp >= %s AND timestamp <= %s
+        GROUP BY game_id, name, provider
+        HAVING AVG(extra) {op} %s
+        ORDER BY media {order}
+    """
+    params = [casa, start, end, extra]
+    with get_connection() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(query, params)
+        return cur.fetchall()
+
+
 init_db()

--- a/templates/index.html
+++ b/templates/index.html
@@ -147,6 +147,7 @@
           <a href="/melhores" class="btn btn-primary w-100 mt-2">🎯 Melhores Jogos</a>
           <a href="/historico" class="btn btn-secondary w-100 mt-2">📊 Histórico</a>
           <a href="/historico-registros" class="btn btn-secondary w-100 mt-2">🗂️ Registros</a>
+          <a href="/registro-extra" class="btn btn-secondary w-100 mt-2">📈 Registro Extra</a>
         </div>
       </aside>
 

--- a/templates/registro_extra.html
+++ b/templates/registro_extra.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>📈 Registro por Extra</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+</head>
+<body>
+  <div class="container py-3">
+    <div class="row g-2 mb-3">
+      <div class="col-md-2">
+        <input type="date" id="start" class="form-control" />
+      </div>
+      <div class="col-md-2">
+        <input type="date" id="end" class="form-control" />
+      </div>
+      <div class="col-md-2">
+        <input type="number" id="extra" class="form-control" placeholder="Extra" />
+      </div>
+      <div class="col-md-3 text-end">
+        <button id="btn-filtrar" class="btn btn-success">Filtrar</button>
+        <a href="/" class="btn btn-secondary">Voltar</a>
+      </div>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-dark table-striped" id="extra-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Jogo</th>
+            <th>Média de Unidades</th>
+            <th>Provedor</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <script>
+    document.getElementById('btn-filtrar').addEventListener('click', carregar);
+    document.addEventListener('DOMContentLoaded', carregar);
+
+    async function carregar() {
+      const params = new URLSearchParams();
+      const inicio = document.getElementById('start').value;
+      const fim = document.getElementById('end').value;
+      const val = document.getElementById('extra').value;
+      if (inicio) params.append('dataInicial', inicio);
+      if (fim) params.append('dataFinal', fim);
+      if (val) params.append('extra', val);
+      const resp = await fetch('/api/registro-extra?' + params.toString());
+      if (!resp.ok) return;
+      const dados = await resp.json();
+      const tbody = document.querySelector('#extra-table tbody');
+      tbody.innerHTML = '';
+      for (const row of dados) {
+        const tr = document.createElement('tr');
+        tr.innerHTML =
+          `<td>${row.game_id}</td><td>${row.name}</td>` +
+          `<td>${row.media}</td><td>${row.provider}</td>`;
+        tbody.appendChild(tr);
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add helper to query games by average extra
- expose new `/api/registro-extra` endpoint
- create `/registro-extra` page to filter games by average units
- link new page from main menu

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68813ea06928832eac3bd762f6049657