### PR TITLE
Add provider and units filter on history page

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,7 +323,9 @@ def api_history_records():
     end = request.args.get("end")
     gid = request.args.get("game_id")
     name = request.args.get("name")
-    return jsonify(db.history_records(start, end, gid, name))
+    provider = request.args.get("provider")
+    extra = request.args.get("extra")
+    return jsonify(db.history_records(start, end, gid, name, provider, extra))
 
 
 @app.route("/api/registro-extra")

--- a/db.py
+++ b/db.py
@@ -181,6 +181,8 @@ def history_records(
     end: str | None = None,
     game_id: str | None = None,
     name: str | None = None,
+    provider: str | None = None,
+    extra: str | None = None,
     casa: str = "cbet",
 ):
     """Retorna registros filtrados da tabela rtp_history."""
@@ -198,6 +200,12 @@ def history_records(
     if name:
         where.append("lower(name) LIKE %s")
         params.append(f"%{name.lower()}%")
+    if provider:
+        where.append("lower(provider) LIKE %s")
+        params.append(f"%{provider.lower()}%")
+    if extra:
+        where.append("CAST(extra AS TEXT) LIKE %s")
+        params.append(f"%{extra}%")
     where_sql = f"WHERE {' AND '.join(where)}" if where else ""
     query = f"""
         SELECT game_id, name, provider, rtp, extra, rtp_status, timestamp

--- a/templates/historico_grid.html
+++ b/templates/historico_grid.html
@@ -20,10 +20,16 @@
       <div class="col-md-2">
         <input type="number" id="game-id" class="form-control" placeholder="ID do jogo" />
       </div>
-      <div class="col-md-3">
+      <div class="col-md-2">
         <input type="text" id="name" class="form-control" placeholder="Nome do jogo" />
       </div>
-      <div class="col-md-3 text-end">
+      <div class="col-md-2">
+        <input type="text" id="provider" class="form-control" placeholder="Provedor" />
+      </div>
+      <div class="col-md-2">
+        <input type="number" id="extra" class="form-control" placeholder="Unidades" />
+      </div>
+      <div class="col-md-2 text-end">
         <button id="btn-filtrar" class="btn btn-success">Filtrar</button>
         <a href="/" class="btn btn-secondary">Voltar</a>
       </div>
@@ -55,10 +61,14 @@
       const fim = document.getElementById('end').value;
       const gidValue = document.getElementById('game-id').value.trim();
       const nome = document.getElementById('name').value;
+      const provedor = document.getElementById('provider').value;
+      const unidades = document.getElementById('extra').value.trim();
       if (inicio) params.append('start', inicio);
       if (fim) params.append('end', fim);
       if (gidValue) params.append('game_id', gidValue);
       if (nome) params.append('name', nome);
+      if (provedor) params.append('provider', provedor);
+      if (unidades) params.append('extra', unidades);
       const resp = await fetch('/api/history/records?' + params.toString());
       if (!resp.ok) return;
       const dados = await resp.json();


### PR DESCRIPTION
## Summary
- add provider and extra inputs to `historico-registros`
- include new parameters in request fetch
- extend `/api/history/records` to accept provider and extra
- update DB query helper

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6886ea59da9c832ea4f3da826c3661b4