### PR TITLE
Fix history_records filter params

### DIFF
--- a/db.py
+++ b/db.py
@@ -184,6 +184,8 @@ def history_records(
     end: str | None = None,
     game_id: str | None = None,
     name: str | None = None,
+    provider: str | None = None,
+    extra: str | None = None,
     casa: str = "cgg",
 ):
     """Retorna registros filtrados da tabela rtp_history."""


### PR DESCRIPTION
## Summary
- extend `history_records` to accept provider and extra filters

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6887e9327660832ca29da0b0e9c56ed3